### PR TITLE
support for new kolo/xmlrcp interface

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,40 +1,37 @@
 package client
 
-import (
-    "github.com/kolo/xmlrpc"
-)
+import "github.com/kolo/xmlrpc"
 
 const (
-    Production SystemType = iota
-    Testing
+	Production SystemType = iota
+	Testing
 )
 
 type SystemType int
 
 func (self SystemType) Url() string {
-    if self == Production {
-        return "https://rpc.gandi.net/xmlrpc/"
-    }
-    return "https://rpc.ote.gandi.net/xmlrpc/"
+	if self == Production {
+		return "https://rpc.gandi.net/xmlrpc/"
+	}
+	return "https://rpc.ote.gandi.net/xmlrpc/"
 }
 
 type Client struct {
-    Key string
-    Url string
+	Key string
+	Url string
 }
 
 func New(apiKey string, system SystemType) *Client {
-    return &Client {
-        Key: apiKey,
-        Url: system.Url(),
-    }
+	return &Client{
+		Key: apiKey,
+		Url: system.Url(),
+	}
 }
 
-func (self *Client) Call(serviceMethod string, args interface{}, reply interface{}) error {
-    rpc, err := xmlrpc.NewClient(self.Url, nil)
-    if err != nil {
-        return err
-    }
-
-    return rpc.Call(serviceMethod, args, reply)
+func (self *Client) Call(serviceMethod string, args []interface{}, reply interface{}) error {
+	rpc, err := xmlrpc.NewClient(self.Url, nil)
+	if err != nil {
+		return err
+	}
+	return rpc.Call(serviceMethod, args, reply)
 }

--- a/contact/contact.go
+++ b/contact/contact.go
@@ -1,79 +1,76 @@
 package contact
 
-import (
-    "github.com/kolo/xmlrpc"
-    "github.com/prasmussen/gandi-api/client"
-)
+import "github.com/prasmussen/gandi-api/client"
 
 type Contact struct {
-    *client.Client
+	*client.Client
 }
 
 func New(c *client.Client) *Contact {
-    return &Contact{c}
+	return &Contact{c}
 }
 
 // Get contact financial balance
 func (self *Contact) Balance() (*BalanceInformation, error) {
-    var res map[string]interface{}
-    params := xmlrpc.Params{Params: []interface{}{self.Key}}
-    if err := self.Call("contact.balance", params, &res); err != nil {
-        return nil, err
-    }
-    return toBalanceInformation(res), nil
+	var res map[string]interface{}
+	params := []interface{}{self.Key}
+	if err := self.Call("contact.balance", params, &res); err != nil {
+		return nil, err
+	}
+	return toBalanceInformation(res), nil
 }
 
 // Get contact information
 func (self *Contact) Info(handle string) (*ContactInformation, error) {
-    var res map[string]interface{}
+	var res map[string]interface{}
 
-    var params xmlrpc.Params
-    if handle == "" {
-        params = xmlrpc.Params{Params: []interface{}{self.Key}}
-    } else {
-        params = xmlrpc.Params{Params: []interface{}{self.Key, handle}}
-    }
-    if err := self.Call("contact.info", params, &res); err != nil {
-        return nil, err
-    }
-    return toContactInformation(res), nil
+	var params []interface{}
+	if handle == "" {
+		params = []interface{}{self.Key}
+	} else {
+		params = []interface{}{self.Key, handle}
+	}
+	if err := self.Call("contact.info", params, &res); err != nil {
+		return nil, err
+	}
+	return toContactInformation(res), nil
 }
 
 // Create a contact
 func (self *Contact) Create(opts ContactCreate) (*ContactInformation, error) {
-    var res map[string]interface{}
-    createArgs := xmlrpc.Struct{
-        "given": opts.Firstname,
-        "family": opts.Lastname,
-        "email": opts.Email,
-        "password": opts.Password,
-        "streetaddr": opts.Address,
-        "zip": opts.Zipcode,
-        "city": opts.City,
-        "country": opts.Country,
-        "phone": opts.Phone,
-        "type": opts.ContactType(),
-    }
+	var res map[string]interface{}
+	createArgs := map[string]interface{}{
+		"given":      opts.Firstname,
+		"family":     opts.Lastname,
+		"email":      opts.Email,
+		"password":   opts.Password,
+		"streetaddr": opts.Address,
+		"zip":        opts.Zipcode,
+		"city":       opts.City,
+		"country":    opts.Country,
+		"phone":      opts.Phone,
+		"type":       opts.ContactType(),
+	}
 
-    params := xmlrpc.Params{Params: []interface{}{self.Key, createArgs}}
-    if err := self.Call("contact.create", params, &res); err != nil {
-        return nil, err
-    }
-    return toContactInformation(res), nil
+	params := []interface{}{self.Key, createArgs}
+	if err := self.Call("contact.create", params, &res); err != nil {
+		return nil, err
+	}
+	return toContactInformation(res), nil
 }
 
 // Delete a contact
 func (self *Contact) Delete(handle string) (bool, error) {
-    var res bool
+	var res bool
 
-    var params xmlrpc.Params
-    if handle == "" {
-        params = xmlrpc.Params{Params: []interface{}{self.Key}}
-    } else {
-        params = xmlrpc.Params{Params: []interface{}{self.Key, handle}}
-    }
-    if err := self.Call("contact.delete", params, &res); err != nil {
-        return false, err
-    }
-    return res, nil
+	var params []interface{}
+	if handle == "" {
+		params = []interface{}{self.Key}
+	} else {
+		params = []interface{}{self.Key, handle}
+	}
+	if err := self.Call("contact.delete", params, &res); err != nil {
+		return false, err
+	}
+	return res, nil
 }

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1,79 +1,77 @@
 package domain
 
 import (
-    "github.com/kolo/xmlrpc"
-    "github.com/prasmussen/gandi-api/operation"
-    "github.com/prasmussen/gandi-api/client"
+	"github.com/prasmussen/gandi-api/client"
+	"github.com/prasmussen/gandi-api/operation"
 )
 
 type Domain struct {
-    *client.Client
+	*client.Client
 }
 
 func New(c *client.Client) *Domain {
-    return &Domain{c}
+	return &Domain{c}
 }
 
 // Check the availability of some domain
 func (self *Domain) Available(name string) (string, error) {
-    var result map[string]interface{}
-    params := xmlrpc.Params{Params: []interface{}{self.Key, []interface{}{name}}}
-    if err := self.Call("domain.available", params, &result); err != nil {
-        return "", err
-    }
-    return result[name].(string), nil
+	var result map[string]interface{}
+	params := []interface{}{self.Key, name}
+	if err := self.Call("domain.available", params, &result); err != nil {
+		return "", err
+	}
+	return result[name].(string), nil
 }
 
 // Get domain information
 func (self *Domain) Info(name string) (*DomainInfo, error) {
-    var res map[string]interface{}
-    params := xmlrpc.Params{Params: []interface{}{self.Key, name}}
-    if err := self.Call("domain.info", params, &res); err != nil {
-        return nil, err
-    }
-    return ToDomainInfo(res), nil
+	var res map[string]interface{}
+	params := []interface{}{self.Key, name}
+	if err := self.Call("domain.info", params, &res); err != nil {
+		return nil, err
+	}
+	return ToDomainInfo(res), nil
 }
 
 // List domains associated to the contact represented by apikey
 func (self *Domain) List() ([]*DomainInfoBase, error) {
-    var res []interface{}
-    params := xmlrpc.Params{Params: []interface{}{self.Key}}
-    if err := self.Call("domain.list", params, &res); err != nil {
-        return nil, err
-    }
+	var res []interface{}
+	params := []interface{}{self.Key}
+	if err := self.Call("domain.list", params, &res); err != nil {
+		return nil, err
+	}
 
-    domains := make([]*DomainInfoBase, 0)
-    for _, r := range res {
-        domain := ToDomainInfoBase(r.(xmlrpc.Struct))
-        domains = append(domains, domain)
-    }
-    return domains, nil
+	domains := make([]*DomainInfoBase, 0)
+	for _, r := range res {
+		domain := ToDomainInfoBase(r.(map[string]interface{}))
+		domains = append(domains, domain)
+	}
+	return domains, nil
 }
 
 // Count domains associated to the contact represented by apikey
 func (self *Domain) Count() (int64, error) {
-    var result int64
-    params := xmlrpc.Params{Params: []interface{}{self.Key}}
-    if err := self.Call("domain.count", params, &result); err != nil {
-        return -1, err
-    }
-    return result, nil
+	var result int64
+	params := []interface{}{self.Key}
+	if err := self.Call("domain.count", params, &result); err != nil {
+		return -1, err
+	}
+	return result, nil
 }
 
 // Create a domain
 func (self *Domain) Create(name, contactHandle string, years int64) (*operation.OperationInfo, error) {
-    var res map[string]interface{}
-    createArgs := xmlrpc.Struct{
-        "admin": contactHandle,
-        "bill": contactHandle,
-        "owner": contactHandle,
-        "tech": contactHandle,
-        "duration": years,
-    }
-    params := xmlrpc.Params{Params: []interface{}{self.Key, name, createArgs}}
-    if err := self.Call("domain.create", params, &res); err != nil {
-        return nil, err
-    }
-    return operation.ToOperationInfo(res), nil
+	var res map[string]interface{}
+	createArgs := map[string]interface{}{
+		"admin":    contactHandle,
+		"bill":     contactHandle,
+		"owner":    contactHandle,
+		"tech":     contactHandle,
+		"duration": years,
+	}
+	params := []interface{}{self.Key, name, createArgs}
+	if err := self.Call("domain.create", params, &res); err != nil {
+		return nil, err
+	}
+	return operation.ToOperationInfo(res), nil
 }
-

--- a/domain/zone/record/record.go
+++ b/domain/zone/record/record.go
@@ -1,76 +1,73 @@
 package record
 
-import (
-    "github.com/kolo/xmlrpc"
-    "github.com/prasmussen/gandi-api/client"
-)
+import "github.com/prasmussen/gandi-api/client"
 
 type Record struct {
-    *client.Client
+	*client.Client
 }
 
 func New(c *client.Client) *Record {
-    return &Record{c}
+	return &Record{c}
 }
 
 // Count number of records for a given zone/version
 func (self *Record) Count(zoneId, version int64) (int64, error) {
-    var result int64
-    params := xmlrpc.Params{Params: []interface{}{self.Key, zoneId, version}}
-    if err := self.Call("domain.zone.record.count", params, &result); err != nil {
-        return -1, err
-    }
-    return result, nil
+	var result int64
+	params := []interface{}{self.Key, zoneId, version}
+	if err := self.Call("domain.zone.record.count", params, &result); err != nil {
+		return -1, err
+	}
+	return result, nil
 }
 
 // List records of a version of a DNS zone
 func (self *Record) List(zoneId, version int64) ([]*RecordInfo, error) {
-    var res []interface{}
-    params := xmlrpc.Params{Params: []interface{}{self.Key, zoneId, version}}
-    if err := self.Call("domain.zone.record.list", params, &res); err != nil {
-        return nil, err
-    }
+	var res []interface{}
+	params := []interface{}{self.Key, zoneId, version}
+	if err := self.Call("domain.zone.record.list", params, &res); err != nil {
+		return nil, err
+	}
 
-    records := make([]*RecordInfo, 0)
-    for _, r := range res {
-        record := ToRecordInfo(r.(xmlrpc.Struct))
-        records = append(records, record)
-    }
-    return records, nil
+	records := make([]*RecordInfo, 0)
+	for _, r := range res {
+		record := ToRecordInfo(r.(map[string]interface{}))
+		records = append(records, record)
+	}
+	return records, nil
 }
 
 // Add a new record to zone
 func (self *Record) Add(args RecordAdd) (*RecordInfo, error) {
-    var res map[string]interface{}
-    createArgs := xmlrpc.Struct{
-        "name": args.Name,
-        "type": args.Type,
-        "value": args.Value,
-        "ttl": args.Ttl,
-    }
+	var res map[string]interface{}
+	createArgs := map[string]interface{}{
+		"name":  args.Name,
+		"type":  args.Type,
+		"value": args.Value,
+		"ttl":   args.Ttl,
+	}
 
-    params := xmlrpc.Params{Params: []interface{}{self.Key, args.Zone, args.Version, createArgs}}
-    if err := self.Call("domain.zone.record.add", params, &res); err != nil {
-        return nil, err
-    }
-    return ToRecordInfo(res), nil
+	params := []interface{}{self.Key, args.Zone, args.Version, createArgs}
+	if err := self.Call("domain.zone.record.add", params, &res); err != nil {
+		return nil, err
+	}
+	return ToRecordInfo(res), nil
 }
 
 // Remove a record from a zone/version
 func (self *Record) Delete(zoneId, version, recordId int64) (bool, error) {
-    var res int64
-    deleteArgs := xmlrpc.Struct{"id": recordId}
-    params := xmlrpc.Params{Params: []interface{}{self.Key, zoneId, version, deleteArgs}}
-    if err := self.Call("domain.zone.record.delete", params, &res); err != nil {
-        return false, err
-    }
-    return (res == 1), nil
+	var res int64
+	deleteArgs := map[string]interface{}{"id": recordId}
+	params := []interface{}{self.Key, zoneId, version, deleteArgs}
+	if err := self.Call("domain.zone.record.delete", params, &res); err != nil {
+		return false, err
+	}
+	return (res == 1), nil
 }
 
 //// Set the current zone of a domain
 //func (self *Record) Set(domainName string, id int64) (*domain.DomainInfo, error) {
 //    var res map[string]interface{}
-//    params := xmlrpc.Params{Params: []interface{}{self.Key, domainName, id}}
+//    params := []interface{}{self.Key, domainName, id}
 //    if err := self.zone.set", params, &res); err != nil {
 //        return nil, err
 //    }

--- a/domain/zone/version/version.go
+++ b/domain/zone/version/version.go
@@ -1,71 +1,68 @@
 package version
 
-import (
-    "github.com/kolo/xmlrpc"
-    "github.com/prasmussen/gandi-api/client"
-)
+import "github.com/prasmussen/gandi-api/client"
 
 type Version struct {
-    *client.Client
+	*client.Client
 }
 
 func New(c *client.Client) *Version {
-    return &Version{c}
+	return &Version{c}
 }
 
 // Count this zone versions
 func (self *Version) Count(zoneId int64) (int64, error) {
-    var result int64
-    params := xmlrpc.Params{Params: []interface{}{self.Key, zoneId}}
-    if err := self.Call("domain.zone.version.count", params, &result); err != nil {
-        return -1, err
-    }
-    return result, nil
+	var result int64
+	params := []interface{}{self.Key, zoneId}
+	if err := self.Call("domain.zone.version.count", params, &result); err != nil {
+		return -1, err
+	}
+	return result, nil
 }
 
 // List this zone versions, with their creation date
 func (self *Version) List(zoneId int64) ([]*VersionInfo, error) {
-    var res []interface{}
-    params := xmlrpc.Params{Params: []interface{}{self.Key, zoneId}}
-    if err := self.Call("domain.zone.version.list", params, &res); err != nil {
-        return nil, err
-    }
+	var res []interface{}
+	params := []interface{}{self.Key, zoneId}
+	if err := self.Call("domain.zone.version.list", params, &res); err != nil {
+		return nil, err
+	}
 
-    versions := make([]*VersionInfo, 0)
-    for _, r := range res {
-        version := ToVersionInfo(r.(xmlrpc.Struct))
-        versions = append(versions, version)
-    }
-    return versions, nil
+	versions := make([]*VersionInfo, 0)
+	for _, r := range res {
+		version := ToVersionInfo(r.(map[string]interface{}))
+		versions = append(versions, version)
+	}
+	return versions, nil
 }
 
 // Create a new version from another version. This will duplicate the version’s records
 func (self *Version) New(zoneId, version int64) (int64, error) {
-    var res int64
+	var res int64
 
-    params := xmlrpc.Params{Params: []interface{}{self.Key, zoneId, version}}
-    if err := self.Call("domain.zone.version.new", params, &res); err != nil {
-        return -1, err
-    }
-    return res, nil
+	params := []interface{}{self.Key, zoneId, version}
+	if err := self.Call("domain.zone.version.new", params, &res); err != nil {
+		return -1, err
+	}
+	return res, nil
 }
 
 // Delete a specific version
 func (self *Version) Delete(zoneId, version int64) (bool, error) {
-    var res bool
-    params := xmlrpc.Params{Params: []interface{}{self.Key, zoneId, version}}
-    if err := self.Call("domain.zone.version.delete", params, &res); err != nil {
-        return false, err
-    }
-    return res, nil
+	var res bool
+	params := []interface{}{self.Key, zoneId, version}
+	if err := self.Call("domain.zone.version.delete", params, &res); err != nil {
+		return false, err
+	}
+	return res, nil
 }
 
 // Set the active version of a zone
 func (self *Version) Set(zoneId, version int64) (bool, error) {
-    var res bool
-    params := xmlrpc.Params{Params: []interface{}{self.Key, zoneId, version}}
-    if err := self.Call("domain.zone.version.set", params, &res); err != nil {
-        return false, err
-    }
-    return res, nil
+	var res bool
+	params := []interface{}{self.Key, zoneId, version}
+	if err := self.Call("domain.zone.version.set", params, &res); err != nil {
+		return false, err
+	}
+	return res, nil
 }

--- a/domain/zone/zone.go
+++ b/domain/zone/zone.go
@@ -1,82 +1,81 @@
 package zone
 
 import (
-    "github.com/kolo/xmlrpc"
-    "github.com/prasmussen/gandi-api/domain"
-    "github.com/prasmussen/gandi-api/client"
+	"github.com/prasmussen/gandi-api/client"
+	"github.com/prasmussen/gandi-api/domain"
 )
 
 type Zone struct {
-    *client.Client
+	*client.Client
 }
 
 func New(c *client.Client) *Zone {
-    return &Zone{c}
+	return &Zone{c}
 }
 
 // Counts accessible zones
 func (self *Zone) Count() (int64, error) {
-    var result int64
-    params := xmlrpc.Params{Params: []interface{}{self.Key}}
-    if err := self.Call("domain.zone.count", params, &result); err != nil {
-        return -1, err
-    }
-    return result, nil
+	var result int64
+	params := []interface{}{self.Key}
+	if err := self.Call("domain.zone.count", params, &result); err != nil {
+		return -1, err
+	}
+	return result, nil
 }
 
 // Get zone information
 func (self *Zone) Info(id int64) (*ZoneInfo, error) {
-    var res map[string]interface{}
-    params := xmlrpc.Params{Params: []interface{}{self.Key, id}}
-    if err := self.Call("domain.zone.info", params, &res); err != nil {
-        return nil, err
-    }
-    return ToZoneInfo(res), nil
+	var res map[string]interface{}
+	params := []interface{}{self.Key, id}
+	if err := self.Call("domain.zone.info", params, &res); err != nil {
+		return nil, err
+	}
+	return ToZoneInfo(res), nil
 }
 
 // List accessible DNS zones.
 func (self *Zone) List() ([]*ZoneInfoBase, error) {
-    var res []interface{}
-    params := xmlrpc.Params{Params: []interface{}{self.Key}}
-    if err := self.Call("domain.zone.list", params, &res); err != nil {
-        return nil, err
-    }
+	var res []interface{}
+	params := []interface{}{self.Key}
+	if err := self.Call("domain.zone.list", params, &res); err != nil {
+		return nil, err
+	}
 
-    zones := make([]*ZoneInfoBase, 0)
-    for _, r := range res {
-        zone := ToZoneInfoBase(r.(xmlrpc.Struct))
-        zones = append(zones, zone)
-    }
-    return zones, nil
+	zones := make([]*ZoneInfoBase, 0)
+	for _, r := range res {
+		zone := ToZoneInfoBase(r.(map[string]interface{}))
+		zones = append(zones, zone)
+	}
+	return zones, nil
 }
 
 // Create a zone
 func (self *Zone) Create(name string) (*ZoneInfo, error) {
-    var res map[string]interface{}
-    createArgs := xmlrpc.Struct{"name": name}
-    params := xmlrpc.Params{Params: []interface{}{self.Key, createArgs}}
-    if err := self.Call("domain.zone.create", params, &res); err != nil {
-        return nil, err
-    }
-    return ToZoneInfo(res), nil
+	var res map[string]interface{}
+	createArgs := map[string]interface{}{"name": name}
+	params := []interface{}{self.Key, createArgs}
+	if err := self.Call("domain.zone.create", params, &res); err != nil {
+		return nil, err
+	}
+	return ToZoneInfo(res), nil
 }
 
 // Delete a zone
 func (self *Zone) Delete(id int64) (bool, error) {
-    var res bool
-    params := xmlrpc.Params{Params: []interface{}{self.Key, id}}
-    if err := self.Call("domain.zone.delete", params, &res); err != nil {
-        return false, err
-    }
-    return res, nil
+	var res bool
+	params := []interface{}{self.Key, id}
+	if err := self.Call("domain.zone.delete", params, &res); err != nil {
+		return false, err
+	}
+	return res, nil
 }
 
 // Set the current zone of a domain
 func (self *Zone) Set(domainName string, id int64) (*domain.DomainInfo, error) {
-    var res map[string]interface{}
-    params := xmlrpc.Params{Params: []interface{}{self.Key, domainName, id}}
-    if err := self.Call("domain.zone.set", params, &res); err != nil {
-        return nil, err
-    }
-    return domain.ToDomainInfo(res), nil
+	var res map[string]interface{}
+	params := []interface{}{self.Key, domainName, id}
+	if err := self.Call("domain.zone.set", params, &res); err != nil {
+		return nil, err
+	}
+	return domain.ToDomainInfo(res), nil
 }

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -1,59 +1,60 @@
 package operation
 
-import (
-    "github.com/kolo/xmlrpc"
-    "github.com/prasmussen/gandi-api/client"
-)
+import "github.com/prasmussen/gandi-api/client"
 
 type Operation struct {
-    *client.Client
+	*client.Client
 }
 
 func New(c *client.Client) *Operation {
-    return &Operation{c}
+	return &Operation{c}
 }
 
 // Count operations created by this contact
 func (self *Operation) Count() (int64, error) {
-    var result int64
-    params := xmlrpc.Params{Params: []interface{}{self.Key}}
-    if err := self.Call("operation.count", params, &result); err != nil {
-        return -1, err
-    }
-    return result, nil
+	var result int64
+	// params := Params{Params: []interface{}{self.Key}}
+	params := []interface{}{self.Key}
+	if err := self.Call("operation.count", params, &result); err != nil {
+		return -1, err
+	}
+	return result, nil
 }
 
 // Get operation information
 func (self *Operation) Info(id int64) (*OperationInfo, error) {
-    var res map[string]interface{}
-    params := xmlrpc.Params{Params: []interface{}{self.Key, id}}
-    if err := self.Call("operation.info", params, &res); err != nil {
-        return nil, err
-    }
-    return ToOperationInfo(res), nil
+	var res map[string]interface{}
+	// params := Params{Params: []interface{}{self.Key, id}}
+	params := []interface{}{self.Key, id}
+	if err := self.Call("operation.info", params, &res); err != nil {
+		return nil, err
+	}
+	return ToOperationInfo(res), nil
 }
 
 // Cancel an operation
 func (self *Operation) Cancel(id int64) (bool, error) {
-    var res bool
-    params := xmlrpc.Params{Params: []interface{}{self.Key, id}}
-    if err := self.Call("operation.cancel", params, &res); err != nil {
-        return false, err
-    }
-    return res, nil
+	var res bool
+	// params := Params{Params: []interface{}{self.Key, id}}
+	params := []interface{}{self.Key, id}
+	if err := self.Call("operation.cancel", params, &res); err != nil {
+		return false, err
+	}
+	return res, nil
 }
 
 // List operations created by this contact
 func (self *Operation) List() ([]*OperationInfo, error) {
-    var res []interface{}
-    params := xmlrpc.Params{Params: []interface{}{self.Key}}
-    if err := self.Call("operation.list", params, &res); err != nil {
-        return nil, err
-    }
+	var res []interface{}
+	// params := Params{Params: []interface{}{self.Key}}
+	params := []interface{}{self.Key}
+	if err := self.Call("operation.list", params, &res); err != nil {
+		return nil, err
+	}
 
-    operations := make([]*OperationInfo, len(res), len(res))
-    for i, r := range res {
-        operations[i] = ToOperationInfo(r.(xmlrpc.Struct))
-    }
-    return operations, nil
+	operations := make([]*OperationInfo, len(res), len(res))
+	for i, r := range res {
+		operations[i] = ToOperationInfo(r.(map[string]interface{}))
+	}
+	return operations, nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,79 +1,76 @@
 package util
 
-import (
-    "github.com/kolo/xmlrpc"
-    "time"
-)
+import "time"
 
 func ToStringSlice(is []interface{}) []string {
-    ss := make([]string, len(is), len(is))
+	ss := make([]string, len(is), len(is))
 
-    for i, _ := range is {
-        ss[i] = is[i].(string)
-    }
-    return ss
+	for i, _ := range is {
+		ss[i] = is[i].(string)
+	}
+	return ss
 }
 
 func ToString(i interface{}) string {
-    if v, ok := i.(string); ok {
-        return v
-    }
-    return ""
+	if v, ok := i.(string); ok {
+		return v
+	}
+	return ""
 }
 
 func ToTime(i interface{}) time.Time {
-    if v, ok := i.(time.Time); ok {
-        return v
-    }
-    var t time.Time
-    return t
+	if v, ok := i.(time.Time); ok {
+		return v
+	}
+	var t time.Time
+	return t
 }
 
 func ToInterfaceSlice(i interface{}) []interface{} {
-    if v, ok := i.([]interface{}); ok {
-        return v
-    }
-    var s []interface{}
-    return s
+	if v, ok := i.([]interface{}); ok {
+		return v
+	}
+	var s []interface{}
+	return s
 }
 
 func ToInt64(i interface{}) int64 {
-    if v, ok := i.(int64); ok {
-        return v
-    }
-    var n int64
-    return n
+	if v, ok := i.(int64); ok {
+		return v
+	}
+	var n int64
+	return n
 }
 
 func ToFloat64(i interface{}) float64 {
-    if v, ok := i.(float64); ok {
-        return v
-    }
-    var n float64
-    return n
+	if v, ok := i.(float64); ok {
+		return v
+	}
+	var n float64
+	return n
 }
 
-func ToXmlrpcStruct(i interface{}) xmlrpc.Struct {
-    if v, ok := i.(xmlrpc.Struct); ok {
-        return v
-    }
-    var s xmlrpc.Struct
-    return s
+func ToXmlrpcStruct(i interface{}) map[string]interface{} {
+	if v, ok := i.(map[string]interface{}); ok {
+		return v
+	}
+	var s map[string]interface{}
+	return s
 }
 
 func ToBool(i interface{}) bool {
-    if v, ok := i.(bool); ok {
-        return v
-    }
-    var b bool
-    return b
+	if v, ok := i.(bool); ok {
+		return v
+	}
+	var b bool
+	return b
 }
 
 func ToIntSlice(is []interface{}) []int64 {
-    numbers := make([]int64, len(is), len(is))
+	numbers := make([]int64, len(is), len(is))
 
-    for i, _ := range is {
-        numbers[i] = ToInt64(is[i])
-    }
-    return numbers
+	for i, _ := range is {
+		numbers[i] = ToInt64(is[i])
+	}
+	return numbers
 }


### PR DESCRIPTION
Just learning go, so this solution might be sub-optimal but wanted to use your library and it seems that the underlying `kolo/xmlrpc` interface has changed and its's not exposing the structs anymore, thus the type assertions/convertions were failing. Also saw that the client is slightly different and takes a slice of []interface{} instead of the struct as an argument. Without it it was not passing the arguments correctly and I was chaising the auth-error. My testing was limited and only was able to pull the domain information so I am concluding the client and argument passing works. Other changes were auto-formatted by my editor. Feel like they make it more readable so left them in this PR. Please let me know if you get  a chance if this is a good direction. 