### PR TITLE
add update zone record method

### DIFF
--- a/domain/zone/record/record.go
+++ b/domain/zone/record/record.go
@@ -64,6 +64,32 @@ func (self *Record) Delete(zoneId, version, recordId int64) (bool, error) {
 	return (res == 1), nil
 }
 
+// Update a record from zone/version
+func (self *Record) Update(args RecordUpdate) ([]*RecordInfo, error) {
+	var res []interface{}
+	updateArgs := map[string]interface{}{
+		"name":  args.Name,
+		"type":  args.Type,
+		"value": args.Value,
+		"ttl":   args.Ttl,
+	}
+	updateOpts := map[string]int64{
+		"id": args.Id,
+	}
+
+	params := []interface{}{self.Key, args.Zone, args.Version, updateOpts, updateArgs}
+	if err := self.Call("domain.zone.record.update", params, &res); err != nil {
+		return nil, err
+	}
+
+	records := make([]*RecordInfo, 0)
+	for _, r := range res {
+		record := ToRecordInfo(r.(map[string]interface{}))
+		records = append(records, record)
+	}
+	return records, nil
+}
+
 //// Set the current zone of a domain
 //func (self *Record) Set(domainName string, id int64) (*domain.DomainInfo, error) {
 //    var res map[string]interface{}

--- a/domain/zone/record/structs.go
+++ b/domain/zone/record/structs.go
@@ -1,20 +1,28 @@
 package record
 
-
 type RecordInfo struct {
-    Id int64
-    Name string
-    Ttl int64
-    Type string
-    Value string
+	Id    int64
+	Name  string
+	Ttl   int64
+	Type  string
+	Value string
 }
 
 type RecordAdd struct {
-    Zone int64 `goptions:"-z, --zone, obligatory, description='Zone id'"`
-    Version int64 `goptions:"-v, --version, obligatory, description='Zone version'"`
-    Name string `goptions:"-n, --name, obligatory, description='Record name. Relative name, may contain leading wildcard. @ for empty name'"`
-    Type string `goptions:"-t, --type, obligatory, description='Record type'"`
-    Value string `goptions:"-V, --value, obligatory, description='Value for record. Semantics depends on the record type.'"`
-    Ttl int64 `goptions:"-T, --ttl, description='Time to live, in seconds, between 5 minutes and 30 days'"`
+	Zone    int64  `goptions:"-z, --zone, obligatory, description='Zone id'"`
+	Version int64  `goptions:"-v, --version, obligatory, description='Zone version'"`
+	Name    string `goptions:"-n, --name, obligatory, description='Record name. Relative name, may contain leading wildcard. @ for empty name'"`
+	Type    string `goptions:"-t, --type, obligatory, description='Record type'"`
+	Value   string `goptions:"-V, --value, obligatory, description='Value for record. Semantics depends on the record type.'"`
+	Ttl     int64  `goptions:"-T, --ttl, description='Time to live, in seconds, between 5 minutes and 30 days'"`
 }
 
+type RecordUpdate struct {
+	Zone    int64  `goptions:"-z, --zone, obligatory, description='Zone id'"`
+	Version int64  `goptions:"-v, --version, obligatory, description='Zone version'"`
+	Name    string `goptions:"-n, --name, obligatory, description='Record name. Relative name, may contain leading wildcard. @ for empty name'"`
+	Type    string `goptions:"-t, --type, obligatory, description='Record type'"`
+	Value   string `goptions:"-V, --value, obligatory, description='Value for record. Semantics depends on the record type.'"`
+	Ttl     int64  `goptions:"-T, --ttl, description='Time to live, in seconds, between 5 minutes and 30 days'"`
+	Id      int64  `goptions:"-r, --record, obligatory, description='Record id'"`
+}


### PR DESCRIPTION
This adds functionality to modify records in zone/version in-place and return a slice of pointers to the modified records. 