### PR TITLE
Adjust for Gandi's API change 2017-08-02

### DIFF
--- a/domain/zone/record/record.go
+++ b/domain/zone/record/record.go
@@ -73,7 +73,7 @@ func (self *Record) Update(args RecordUpdate) ([]*RecordInfo, error) {
 		"value": args.Value,
 		"ttl":   args.Ttl,
 	}
-	updateOpts := map[string]int64{
+	updateOpts := map[string]string{
 		"id": args.Id,
 	}
 

--- a/domain/zone/record/structs.go
+++ b/domain/zone/record/structs.go
@@ -1,7 +1,7 @@
 package record
 
 type RecordInfo struct {
-	Id    int64
+	Id    string
 	Name  string
 	Ttl   int64
 	Type  string
@@ -24,7 +24,7 @@ type RecordUpdate struct {
 	Type    string `goptions:"-t, --type, obligatory, description='Record type'"`
 	Value   string `goptions:"-V, --value, obligatory, description='Value for record. Semantics depends on the record type.'"`
 	Ttl     int64  `goptions:"-T, --ttl, description='Time to live, in seconds, between 5 minutes and 30 days'"`
-	Id      int64  `goptions:"-r, --record, obligatory, description='Record id'"`
+	Id      string `goptions:"-r, --record, obligatory, description='Record id'"`
 }
 
 type RecordSet map[string]interface{}

--- a/domain/zone/record/util.go
+++ b/domain/zone/record/util.go
@@ -1,16 +1,15 @@
 package record
 
 import (
-    "github.com/prasmussen/gandi-api/util"
+	"github.com/prasmussen/gandi-api/util"
 )
 
-
 func ToRecordInfo(res map[string]interface{}) *RecordInfo {
-    return &RecordInfo{
-        Id: util.ToInt64(res["id"]),
-        Name: util.ToString(res["name"]),
-        Ttl: util.ToInt64(res["ttl"]),
-        Type: util.ToString(res["type"]),
-        Value: util.ToString(res["value"]),
-    }
+	return &RecordInfo{
+		Id:    util.ToString(res["id"]),
+		Name:  util.ToString(res["name"]),
+		Ttl:   util.ToInt64(res["ttl"]),
+		Type:  util.ToString(res["type"]),
+		Value: util.ToString(res["value"]),
+	}
 }


### PR DESCRIPTION
* 2017-08-02 BREAKING CHANGE: ZoneRecordReturn id changed from int to string (due to XML-RPC limitations for the integer type being reached)
* See http://doc.rpc.gandi.net/changelog/changelog-3.3.36.html