### PR TITLE
Add support to modify nameservers 

### DIFF
--- a/domain/nameservers/nameservers.go
+++ b/domain/nameservers/nameservers.go
@@ -1,0 +1,26 @@
+package zone
+
+import (
+	"fmt"
+	"github.com/prasmussen/gandi-api/client"
+	"github.com/prasmussen/gandi-api/domain"
+)
+
+type Nameservers struct {
+	*client.Client
+}
+
+func New(c *client.Client) *Nameservers {
+	return &Nameservers{c}
+}
+
+// Set the current zone of a domain
+func (self *Nameservers) Set(domainName string, nameservers []string) (*domain.DomainInfo, error) {
+	var res map[string]interface{}
+	fmt.Println(nameservers)
+	params := []interface{}{self.Key, domainName, nameservers}
+	if err := self.Call("domain.nameservers.set", params, &res); err != nil {
+		return nil, err
+	}
+	return domain.ToDomainInfo(res), nil
+}


### PR DESCRIPTION
adds ability to update the nameserver of a domain using "domain.nameservers.set" api call.