### PR TITLE
zone.Create() should include ?sharing_id= in URI

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -22,6 +22,9 @@ const (
 	LiveDNS
 )
 
+// Enable/disable debug output:
+const debug = false
+
 // SystemType is the type used to resolve gandi API address
 type SystemType int
 
@@ -85,6 +88,9 @@ func (c *Client) DoRest(req *http.Request, decoded interface{}) (*http.Response,
 			e = json.Unmarshal(b, decoded)
 			if e != nil {
 				return nil, e
+			}
+			if resp.StatusCode == http.StatusBadRequest {
+				return nil, fmt.Errorf("the server returned 400 bad request (%v)", string(b))
 			}
 		}
 		resp.Body = ioutil.NopCloser(bytes.NewReader(b))
@@ -151,9 +157,15 @@ func (c *Client) Delete(URI string, decoded interface{}) (*http.Response, error)
 // - decodes the returned data if a not null decoded pointer is provided
 // - ensures the status code is an HTTP accepted
 func (c *Client) Post(URI string, data interface{}, decoded interface{}) (*http.Response, error) {
+	if debug {
+		fmt.Printf("DEBUG: POST URI=%s\n", URI)
+	}
 	req, err := c.NewJSONRequest("POST", URI, data)
 	if err != nil {
 		return nil, err
+	}
+	if debug {
+		fmt.Printf("DEBUG: POST req=%v decoded=%v\n", req, decoded)
 	}
 	resp, err := c.DoRest(req, decoded)
 	if err != nil {

--- a/live_dns/test_helpers/test_helper.go
+++ b/live_dns/test_helpers/test_helper.go
@@ -14,6 +14,7 @@ import (
 
 // RunTest starts an http, asserts calls provided as arguments and writes the response
 func RunTest(t testing.TB, method, uri, requestBody, responseBody string, code int, call func(t testing.TB, c *client.Client)) {
+	t.Helper()
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			err := r.Body.Close()

--- a/live_dns/zone/zone.go
+++ b/live_dns/zone/zone.go
@@ -9,6 +9,9 @@ import (
 	"github.com/prasmussen/gandi-api/live_dns/record"
 )
 
+// Enable/disable debug output:
+const debug = false
+
 // Zone holds the zone client structure
 type Zone struct {
 	*client.Client
@@ -28,27 +31,33 @@ func (z *Zone) List() (zones []*Info, err error) {
 // InfoByUUID Gets zone information from its UUID
 func (z *Zone) InfoByUUID(uuid uuid.UUID) (info *Info, err error) {
 	_, err = z.Get(fmt.Sprintf("/zones/%s", uuid), &info)
+	if debug {
+		fmt.Printf("DEBUG: InfoByUUID returned SharingID=%v domain=%v\n", info.SharingID, info.Name)
+	}
 	return
 }
 
 // Info Gets zone information
 func (z *Zone) Info(zoneInfo Info) (info *Info, err error) {
 	if zoneInfo.UUID == nil {
-		return nil, fmt.Errorf("could get zone info %s without an id", zoneInfo.Name)
+		return nil, fmt.Errorf("can not get zone info %s without an id", zoneInfo.Name)
 	}
 	return z.InfoByUUID(*zoneInfo.UUID)
 }
 
 // Create creates a new zone
 func (z *Zone) Create(zoneInfo Info) (status *CreateStatus, err error) {
-	_, err = z.Post("/zones", zoneInfo, &status)
+	if debug {
+		fmt.Printf("DEBUG: Create WILL SET SharingID=%v domain=%v\n", zoneInfo.SharingID, zoneInfo.Name)
+	}
+	_, err = z.Post(fmt.Sprintf("/zones?sharing_id=%s", zoneInfo.SharingID), zoneInfo, &status)
 	return
 }
 
 // Update updates an existing zone
 func (z *Zone) Update(zoneInfo Info) (status *Status, err error) {
 	if zoneInfo.UUID == nil {
-		return nil, fmt.Errorf("could not update zone %s without an id", zoneInfo.Name)
+		return nil, fmt.Errorf("can not update zone %s without an id", zoneInfo.Name)
 	}
 	_, err = z.Patch(fmt.Sprintf("/zones/%s", zoneInfo.UUID), zoneInfo, &status)
 	return
@@ -57,7 +66,7 @@ func (z *Zone) Update(zoneInfo Info) (status *Status, err error) {
 // Delete Deletes an existing zone
 func (z *Zone) Delete(zoneInfo Info) (err error) {
 	if zoneInfo.UUID == nil {
-		return fmt.Errorf("could not update zone %s without an id", zoneInfo.Name)
+		return fmt.Errorf("can not update zone %s without an id", zoneInfo.Name)
 	}
 	_, err = z.Client.Delete(fmt.Sprintf("/zones/%s", zoneInfo.UUID), nil)
 	return
@@ -66,7 +75,7 @@ func (z *Zone) Delete(zoneInfo Info) (err error) {
 // Domains lists all domains using a zone
 func (z *Zone) Domains(zoneInfo Info) (domains []*domain.InfoBase, err error) {
 	if zoneInfo.UUID == nil {
-		return nil, fmt.Errorf("could get domains on a zone %s without an id", zoneInfo.Name)
+		return nil, fmt.Errorf("can not get domains on a zone %s without an id", zoneInfo.Name)
 	}
 	_, err = z.Get(fmt.Sprintf("/zones/%s/domains", zoneInfo.UUID), &domains)
 	return
@@ -76,9 +85,13 @@ func (z *Zone) Domains(zoneInfo Info) (domains []*domain.InfoBase, err error) {
 // Set the current zone of a domain
 func (z *Zone) Set(domainName string, zoneInfo Info) (status *Status, err error) {
 	if zoneInfo.UUID == nil {
-		return nil, fmt.Errorf("could attach a domain %s to a zone %s without an id", domainName, zoneInfo.Name)
+		return nil, fmt.Errorf("can not attach a domain %s to a zone %s without an id", domainName, zoneInfo.Name)
+	}
+	if debug {
+		fmt.Printf("DEBUG: Set WILL SET SharingID=%v domain=%s dn=%v\n", zoneInfo.SharingID, domainName, zoneInfo.Name)
 	}
 	_, err = z.Post(fmt.Sprintf("/zones/%s/domains/%s", zoneInfo.UUID, domainName), nil, &status)
+	//_, err = z.Post(fmt.Sprintf("/zones?sharing_id=%s/%s/domains/%s", "FIND THE CODE", zoneInfo.UUID, domainName), nil, &status)
 	return
 }
 

--- a/live_dns/zone/zone.go
+++ b/live_dns/zone/zone.go
@@ -91,7 +91,6 @@ func (z *Zone) Set(domainName string, zoneInfo Info) (status *Status, err error)
 		fmt.Printf("DEBUG: Set WILL SET SharingID=%v domain=%s dn=%v\n", zoneInfo.SharingID, domainName, zoneInfo.Name)
 	}
 	_, err = z.Post(fmt.Sprintf("/zones/%s/domains/%s", zoneInfo.UUID, domainName), nil, &status)
-	//_, err = z.Post(fmt.Sprintf("/zones?sharing_id=%s/%s/domains/%s", "FIND THE CODE", zoneInfo.UUID, domainName), nil, &status)
 	return
 }
 

--- a/live_dns/zone/zone_test.go
+++ b/live_dns/zone/zone_test.go
@@ -145,14 +145,16 @@ func TestList(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
+	testuuid, _ := uuid.Parse("d85976ac-16d8-11e7-bbe1-00163e61ef31")
 	RunTest(t,
-		"POST", "/api/v5/zones",
-		`{"name": "example.com Zone"}`,
+		"POST", "/api/v5/zones?sharing_id=d85976ac-16d8-11e7-bbe1-00163e61ef31",
+		`{"sharing_id":"d85976ac-16d8-11e7-bbe1-00163e61ef31", "name": "example.com Zone"}`,
 		`{"message": "Zone Created", "uuid": "12bb7678-e43e-11e7-80c1-00163e6dc886"}`,
 		http.StatusCreated,
 		func(t testing.TB, z *Zone) {
 			zoneInfo := Info{
-				Name: "example.com Zone",
+				Name:      "example.com Zone",
+				SharingID: &testuuid,
 			}
 			info, err := z.Create(zoneInfo)
 			assert.NoError(t, err)


### PR DESCRIPTION
User-visible enhancements:
* zone.Create() should include ?sharing_id= in URI.
* client.DoRest should propagate BadRequest errors with full error message.
* Fix error messages ("could" -> "can")

Improve debugging and testing:
* client/client.go: Add debug flag and output.
* live_dns/zone/zone.go: Add debug flag and output.
* live_dns/test_helpers/test_helper.go: Mark RunTest() as a t.Helper()
* live_dns/zone/zone_test.go: Update tests to match new features.